### PR TITLE
Add flexible site import pipeline and UI dialog

### DIFF
--- a/sitebuilder/__init__.py
+++ b/sitebuilder/__init__.py
@@ -1,1 +1,6 @@
-﻿
+"""Webineer site builder package."""
+
+from .core.models import Asset, Page, Project
+
+__all__ = ["Asset", "Page", "Project"]
+

--- a/sitebuilder/core/generator.py
+++ b/sitebuilder/core/generator.py
@@ -1,21 +1,50 @@
-﻿from pathlib import Path
+"""Site export helpers."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
 from jinja2 import Environment, FileSystemLoader, select_autoescape
+
 from .models import Project
+
 
 def _env(templates_dir: Path) -> Environment:
     return Environment(
         loader=FileSystemLoader(str(templates_dir)),
-        autoescape=select_autoescape(["html", "xml"])
+        autoescape=select_autoescape(["html", "xml"]),
     )
+
 
 def render_site(project: Project, output_dir: str | Path, templates_dir: Path) -> None:
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
+    assets_root = output_dir / "assets"
+
     # Write CSS
-    css_dir = output_dir / "assets" / "css"
+    css_dir = assets_root / "css"
     css_dir.mkdir(parents=True, exist_ok=True)
     (css_dir / "style.css").write_text(project.css, encoding="utf-8")
+
+    # Write binary assets bundled with the project
+    for asset in project.assets:
+        if not asset.data_base64:
+            continue
+        dest_subdir = {
+            "images": "images",
+            "fonts": "fonts",
+            "media": "media",
+            "js": "js",
+        }.get(asset.kind, "files")
+        dest_dir = assets_root / dest_subdir
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            data = base64.b64decode(asset.data_base64.encode("ascii"))
+        except Exception:
+            continue
+        (dest_dir / asset.name).write_bytes(data)
 
     env = _env(templates_dir)
     tpl = env.get_template("base.html.j2")
@@ -28,6 +57,7 @@ def render_site(project: Project, output_dir: str | Path, templates_dir: Path) -
             title=page.title,
             pages=nav,
             content=page.html,
-            stylesheet_path="assets/css/style.css"
+            stylesheet_path="assets/css/style.css",
         )
         (output_dir / page.filename).write_text(html, encoding="utf-8")
+

--- a/sitebuilder/core/models.py
+++ b/sitebuilder/core/models.py
@@ -1,11 +1,41 @@
-﻿from dataclasses import dataclass, asdict
+"""Data models for the site builder application."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict, field
 from typing import List, Optional
+
 
 @dataclass
 class Page:
     filename: str
     title: str
     html: str
+
+
+@dataclass
+class Asset:
+    """A binary asset bundled with the project."""
+
+    name: str
+    data_base64: str
+    kind: str  # images, fonts, media, js, other
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "data_base64": self.data_base64,
+            "kind": self.kind,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Asset":
+        return cls(
+            name=data.get("name", "asset"),
+            data_base64=data.get("data_base64", ""),
+            kind=data.get("kind", "other"),
+        )
+
 
 @dataclass
 class Project:
@@ -14,6 +44,7 @@ class Project:
     css: str
     output_dir: Optional[str] = None
     version: int = 1
+    assets: List[Asset] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         return {
@@ -22,15 +53,23 @@ class Project:
             "output_dir": self.output_dir,
             "version": self.version,
             "pages": [asdict(p) for p in self.pages],
+            "assets": [asset.to_dict() for asset in self.assets],
         }
 
     @classmethod
     def from_dict(cls, data: dict) -> "Project":
         pages = [Page(**p) for p in data.get("pages", [])]
+        assets_data = data.get("assets", [])
+        assets: List[Asset] = []
+        for asset_data in assets_data:
+            if isinstance(asset_data, dict):
+                assets.append(Asset.from_dict(asset_data))
         return cls(
             name=data.get("name", "My Site"),
             pages=pages,
             css=data.get("css", ""),
             output_dir=data.get("output_dir"),
             version=data.get("version", 1),
+            assets=assets,
         )
+

--- a/sitebuilder/importers.py
+++ b/sitebuilder/importers.py
@@ -1,0 +1,885 @@
+"""Import pipeline for bringing external content into a project."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import importlib
+import json
+import os
+import re
+import shutil
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Callable, Dict, Iterable, Iterator, Literal, Optional
+from urllib.parse import urlparse, urlunparse
+from zipfile import ZipFile
+
+from .core.models import Asset, Page, Project
+
+try:  # pragma: no cover - optional dependency
+    from bs4 import BeautifulSoup  # type: ignore
+except Exception:  # pragma: no cover - graceful fallback
+    BeautifulSoup = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    import markdown as markdown_lib  # type: ignore
+except Exception:  # pragma: no cover
+    markdown_lib = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    import nbformat  # type: ignore
+    from nbconvert import HTMLExporter  # type: ignore
+except Exception:  # pragma: no cover
+    nbformat = None  # type: ignore
+    HTMLExporter = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    import mammoth  # type: ignore
+except Exception:  # pragma: no cover
+    mammoth = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    from docutils.core import publish_parts  # type: ignore
+except Exception:  # pragma: no cover
+    publish_parts = None  # type: ignore
+
+
+SourceType = Literal["folder", "zip", "file"]
+
+
+ALLOWED_EXTS_DEFAULT: set[str] = {
+    ".html",
+    ".htm",
+    ".md",
+    ".markdown",
+    ".txt",
+    ".ipynb",
+    ".rst",
+    ".css",
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".webp",
+    ".svg",
+    ".ico",
+    ".woff",
+    ".woff2",
+    ".ttf",
+    ".otf",
+    ".mp4",
+    ".webm",
+    ".mp3",
+    ".js",
+    ".docx",
+}
+
+
+MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MiB safety cap
+
+
+@dataclass(slots=True)
+class ImportOptions:
+    create_new_project: bool = False
+    page_filename_strategy: Literal["keep", "slugify", "prefix-collisions"] = "slugify"
+    conflict_policy: Literal["overwrite", "keep-both", "skip"] = "keep-both"
+    merge_css: Literal["append", "prepend", "replace"] = "append"
+    rewrite_links: bool = True
+    rewrite_asset_urls: bool = True
+    md_flavor: Literal["gfm", "commonmark"] = "gfm"
+    text_wrap_paragraphs: bool = True
+    set_home_to_index_if_present: bool = True
+    ignore_hidden: bool = True
+    include_js_files: bool = True
+    allowed_extensions: set[str] | None = None
+
+
+@dataclass(slots=True)
+class ImportResult:
+    files_scanned: int = 0
+    pages_imported: int = 0
+    css_files_merged: int = 0
+    assets_copied: int = 0
+    warnings: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class PageCandidate:
+    source_path: Path
+    rel_path: str
+    ext: str
+    title: str = ""
+    body_html: str = ""
+    new_filename: str = ""
+    replace_existing: bool = False
+    skip: bool = False
+
+
+@dataclass(slots=True)
+class AssetCandidate:
+    source_path: Path
+    rel_path: str
+    ext: str
+    kind: str
+    new_name: str = ""
+    content_hash: str = ""
+
+
+def sniff_source_type(path: Path) -> SourceType:
+    path = Path(path)
+    if path.is_dir():
+        return "folder"
+    if path.is_file() and path.suffix.lower() == ".zip":
+        return "zip"
+    return "file"
+
+
+def import_into_project(
+    target_project: Project,
+    source: str | Path,
+    options: ImportOptions,
+    progress_callback: Callable[[int, int], None] | None = None,
+) -> ImportResult:
+    source_path = Path(source)
+    result = ImportResult()
+    allowed_exts = {ext.lower() for ext in (options.allowed_extensions or ALLOWED_EXTS_DEFAULT)}
+
+    cleanup_dirs: list[Path] = []
+    try:
+        source_type = sniff_source_type(source_path)
+        if source_type == "zip":
+            extracted = _extract_zip(source_path, result)
+            if extracted is None:
+                return result
+            cleanup_dirs.append(extracted)
+            base_iter: Iterable[tuple[Path, str]] = _iter_folder(extracted, options, result)
+        elif source_type == "folder":
+            base_iter = _iter_folder(source_path, options, result)
+        else:
+            base_iter = _iter_single(source_path, result)
+
+        files_to_process = [(path, rel) for path, rel in base_iter if path.is_file()]
+        total = len(files_to_process) or 1
+
+        page_candidates: list[PageCandidate] = []
+        css_candidates: list[Path] = []
+        asset_candidates: list[AssetCandidate] = []
+
+        for index, (abs_path, rel_path) in enumerate(files_to_process, start=1):
+            result.files_scanned += 1
+            ext = abs_path.suffix.lower()
+            if allowed_exts and ext not in allowed_exts:
+                result.warnings.append(f"Skipped unsupported file: {rel_path}")
+                if progress_callback:
+                    progress_callback(index, total)
+                continue
+            if ext in {".html", ".htm", ".md", ".markdown", ".txt", ".ipynb", ".rst", ".docx", ".py"}:
+                page_candidates.append(PageCandidate(source_path=abs_path, rel_path=rel_path, ext=ext))
+            elif ext == ".css":
+                css_candidates.append(abs_path)
+            elif ext == ".js":
+                if options.include_js_files:
+                    asset_candidates.append(
+                        AssetCandidate(source_path=abs_path, rel_path=rel_path, ext=ext, kind="js")
+                    )
+            elif ext in {".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".ico"}:
+                asset_candidates.append(
+                    AssetCandidate(source_path=abs_path, rel_path=rel_path, ext=ext, kind="images")
+                )
+            elif ext in {".woff", ".woff2", ".ttf", ".otf"}:
+                asset_candidates.append(
+                    AssetCandidate(source_path=abs_path, rel_path=rel_path, ext=ext, kind="fonts")
+                )
+            elif ext in {".mp4", ".webm", ".mp3"}:
+                asset_candidates.append(
+                    AssetCandidate(source_path=abs_path, rel_path=rel_path, ext=ext, kind="media")
+                )
+            else:
+                result.warnings.append(f"Ignored file: {rel_path}")
+
+            if progress_callback:
+                progress_callback(index, total)
+
+        asset_map = _process_assets(target_project, asset_candidates, result)
+
+        imported_css = _merge_css_files(target_project, css_candidates, asset_map, options, result)
+        if imported_css is not None:
+            target_project.css = imported_css
+
+        page_map = _process_pages(target_project, page_candidates, asset_map, options, result)
+
+        combined_map: Dict[str, str] = {}
+        if options.rewrite_asset_urls:
+            combined_map.update(asset_map)
+        if options.rewrite_links:
+            combined_map.update(page_map)
+
+        _finalize_pages(target_project, page_candidates, combined_map, options, result)
+
+        if progress_callback:
+            progress_callback(total, total)
+
+        return result
+    finally:
+        for tmp in cleanup_dirs:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+def _iter_folder(base: Path, options: ImportOptions, result: ImportResult) -> Iterator[tuple[Path, str]]:
+    base = Path(base)
+    for path in base.rglob("*"):
+        try:
+            if options.ignore_hidden and _is_hidden(path.relative_to(base)):
+                continue
+        except Exception:
+            continue
+        if path.is_symlink():
+            try:
+                resolved = path.resolve()
+            except Exception:
+                result.warnings.append(f"Skipped unreadable symlink: {path}")
+                continue
+            if base not in resolved.parents and resolved != base:
+                result.warnings.append(f"Skipped symlink outside root: {path}")
+                continue
+        rel = path.relative_to(base).as_posix()
+        yield path, rel
+
+
+def _iter_single(path: Path, result: ImportResult) -> Iterator[tuple[Path, str]]:
+    if not path.exists():
+        result.errors.append(f"File not found: {path}")
+        return iter(())
+    return iter([(path, path.name)])
+
+
+def _extract_zip(path: Path, result: ImportResult) -> Path | None:
+    tmp_dir = Path(tempfile.mkdtemp(prefix="sitebuilder_zip_"))
+    try:
+        with ZipFile(path) as zf:
+            for member in zf.infolist():
+                name = member.filename
+                if member.is_dir():
+                    continue
+                normalized = PurePosixPath(name)
+                if ".." in normalized.parts:
+                    result.warnings.append(f"Skipping unsafe zip entry: {name}")
+                    continue
+                dest = tmp_dir.joinpath(*normalized.parts)
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                with zf.open(member) as src, dest.open("wb") as fh:
+                    shutil.copyfileobj(src, fh)
+        return tmp_dir
+    except Exception as exc:  # pragma: no cover - rare
+        result.errors.append(f"Failed to extract zip: {exc}")
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        return None
+
+
+def _process_assets(
+    project: Project,
+    candidates: list[AssetCandidate],
+    result: ImportResult,
+) -> Dict[str, str]:
+    mapping: Dict[str, str] = {}
+    existing_hashes: Dict[str, Asset] = {}
+    for asset in project.assets:
+        try:
+            digest = hashlib.sha1(base64.b64decode(asset.data_base64.encode("ascii"))).hexdigest()
+        except Exception:
+            continue
+        existing_hashes[digest] = asset
+
+    taken_names = {asset.name for asset in project.assets}
+
+    for candidate in candidates:
+        path = candidate.source_path
+        try:
+            size = path.stat().st_size
+        except OSError:
+            result.warnings.append(f"Unable to stat asset: {candidate.rel_path}")
+            continue
+        if size > MAX_FILE_SIZE:
+            result.warnings.append(f"Skipped large asset (>10MB): {candidate.rel_path}")
+            continue
+
+        digest = _hash_file(path)
+        candidate.content_hash = digest
+        if digest in existing_hashes:
+            asset = existing_hashes[digest]
+            export_path = _asset_export_path(asset)
+            normalized = _normalize_rel(candidate.rel_path)
+            mapping[normalized] = export_path
+            mapping.setdefault(Path(candidate.rel_path).name, export_path)
+            continue
+
+        data_base64 = _read_file_base64(path)
+        if data_base64 is None:
+            result.warnings.append(f"Failed to read asset: {candidate.rel_path}")
+            continue
+
+        new_name = _unique_asset_name(path.name, taken_names)
+        taken_names.add(new_name)
+        asset = Asset(name=new_name, data_base64=data_base64, kind=candidate.kind)
+        project.assets.append(asset)
+        existing_hashes[digest] = asset
+        result.assets_copied += 1
+        export_path = _asset_export_path(asset)
+        normalized = _normalize_rel(candidate.rel_path)
+        mapping[normalized] = export_path
+        name_only = Path(candidate.rel_path).name
+        mapping.setdefault(name_only, export_path)
+
+    return mapping
+
+
+def _asset_export_path(asset: Asset) -> str:
+    dest_subdir = {
+        "images": "images",
+        "fonts": "fonts",
+        "media": "media",
+        "js": "js",
+    }.get(asset.kind, "files")
+    return f"assets/{dest_subdir}/{asset.name}"
+
+
+def _merge_css_files(
+    project: Project,
+    candidates: list[Path],
+    asset_map: Dict[str, str],
+    options: ImportOptions,
+    result: ImportResult,
+) -> str | None:
+    if not candidates:
+        return None
+    rewritten_blocks: list[str] = []
+    for css_path in candidates:
+        try:
+            text = css_path.read_text(encoding="utf-8", errors="ignore")
+        except Exception:
+            result.warnings.append(f"Unable to read CSS file: {css_path}")
+            continue
+        if options.rewrite_asset_urls and asset_map:
+            text = rewrite_css_urls(text, lambda value: _rewrite_asset(value, asset_map))
+        rel = css_path.name
+        rewritten_blocks.append(f"/* --- imported: {rel} --- */\n{text.strip()}\n")
+        result.css_files_merged += 1
+
+    if not rewritten_blocks:
+        return None
+
+    merged = "\n\n".join(rewritten_blocks)
+    current = project.css or ""
+    if options.merge_css == "replace":
+        return merged
+    if options.merge_css == "prepend":
+        return f"{merged}\n\n{current}" if current else merged
+    # append
+    return f"{current}\n\n{merged}" if current else merged
+
+
+def _rewrite_asset(value: str, mapping: Dict[str, str]) -> str:
+    normalized = _normalize_rel(value)
+    if normalized in mapping:
+        return mapping[normalized]
+    alt = normalized.lstrip("./")
+    return mapping.get(alt, value)
+
+
+def _process_pages(
+    project: Project,
+    candidates: list[PageCandidate],
+    asset_map: Dict[str, str],
+    options: ImportOptions,
+    result: ImportResult,
+) -> Dict[str, str]:
+    if not candidates:
+        return {}
+
+    page_map: Dict[str, str] = {}
+    for candidate in candidates:
+        try:
+            body_html, title = _convert_page(candidate, options, result)
+        except Exception as exc:  # pragma: no cover - defensive
+            result.warnings.append(f"Failed to convert {candidate.rel_path}: {exc}")
+            candidate.skip = True
+            continue
+        candidate.body_html = body_html
+        candidate.title = title or Path(candidate.rel_path).stem
+
+    # Determine home page preference
+    home_candidate: PageCandidate | None = None
+    if options.set_home_to_index_if_present and candidates:
+        for candidate in candidates:
+            stem = Path(candidate.rel_path).stem.lower()
+            if stem == "index":
+                home_candidate = candidate
+                break
+        if home_candidate is None:
+            home_candidate = candidates[0]
+
+    existing_names = {page.filename for page in project.pages}
+    assigned: set[str] = set()
+
+    for candidate in candidates:
+        if candidate.skip:
+            continue
+        base_name = _determine_base_name(candidate, options)
+        if home_candidate is candidate:
+            base_name = "index"
+        filename = f"{base_name}.html"
+        normalized_rel = _normalize_rel(candidate.rel_path)
+
+        final_name = _resolve_page_conflict(
+            filename, candidate, existing_names, assigned, options, result
+        )
+        if final_name is None:
+            candidate.skip = True
+            continue
+
+        candidate.new_filename = final_name
+        assigned.add(final_name)
+        page_map[normalized_rel] = final_name
+        if normalized_rel != Path(candidate.rel_path).name:
+            page_map[Path(candidate.rel_path).name] = final_name
+
+    return page_map
+
+
+def _determine_base_name(candidate: PageCandidate, options: ImportOptions) -> str:
+    stem = Path(candidate.rel_path).stem
+    if options.page_filename_strategy == "keep":
+        base = re.sub(r"[^a-zA-Z0-9_-]+", "-", stem).strip("-") or "page"
+        return base.lower()
+    if options.page_filename_strategy == "prefix-collisions":
+        slug = re.sub(r"[^a-zA-Z0-9_-]+", "-", stem).strip("-") or "page"
+        return slug.lower()
+    # slugify using title
+    title = candidate.title or stem
+    slug = slugify_filename(title)
+    return slug or "page"
+
+
+def _resolve_page_conflict(
+    filename: str,
+    candidate: PageCandidate,
+    existing: set[str],
+    assigned: set[str],
+    options: ImportOptions,
+    result: ImportResult,
+) -> str | None:
+    target = filename
+    if target in assigned:
+        target = _increment_filename(target, assigned)
+
+    if target in existing:
+        if options.conflict_policy == "overwrite":
+            candidate.replace_existing = True
+            return target
+        if options.conflict_policy == "skip":
+            result.warnings.append(f"Skipped page (conflict): {candidate.rel_path}")
+            return None
+        if options.page_filename_strategy == "prefix-collisions":
+            prefix = hashlib.sha1(candidate.rel_path.encode("utf-8")).hexdigest()[:6]
+            target = f"{prefix}-{target}"
+        target = _increment_filename(target, existing | assigned)
+    return target
+
+
+def _increment_filename(filename: str, taken: set[str]) -> str:
+    stem = Path(filename).stem
+    suffix = Path(filename).suffix or ".html"
+    counter = 2
+    candidate = f"{stem}-{counter}{suffix}"
+    while candidate in taken:
+        counter += 1
+        candidate = f"{stem}-{counter}{suffix}"
+    return candidate
+
+
+def _finalize_pages(
+    project: Project,
+    candidates: list[PageCandidate],
+    mapping: Dict[str, str],
+    options: ImportOptions,
+    result: ImportResult,
+) -> None:
+    for candidate in candidates:
+        if candidate.skip or not candidate.new_filename:
+            continue
+        html = candidate.body_html
+        if mapping and (options.rewrite_links or options.rewrite_asset_urls):
+            html = rewrite_html_links(html, mapping)
+
+        page = Page(filename=candidate.new_filename, title=candidate.title, html=html)
+
+        if candidate.replace_existing:
+            for idx, existing in enumerate(project.pages):
+                if existing.filename == candidate.new_filename:
+                    project.pages[idx] = page
+                    break
+        else:
+            project.pages.append(page)
+        result.pages_imported += 1
+
+
+def _convert_page(
+    candidate: PageCandidate,
+    options: ImportOptions,
+    result: ImportResult,
+) -> tuple[str, str]:
+    path = candidate.source_path
+    ext = candidate.ext
+    if ext in {".html", ".htm"}:
+        html = path.read_text(encoding="utf-8", errors="ignore")
+        title, body = extract_html_title_and_body(html)
+        return body, title
+    if ext in {".md", ".markdown"}:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        html = _convert_markdown(text, options, result)
+        title = _first_heading(text) or Path(candidate.rel_path).stem
+        return html, title
+    if ext == ".txt":
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        html = _convert_text(text, options)
+        title = _first_non_empty_line(text) or Path(candidate.rel_path).stem
+        return html, title
+    if ext == ".ipynb":
+        return _convert_ipynb(path, candidate, result)
+    if ext == ".rst":
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        html = _convert_rst(text, result)
+        title = _first_heading(text) or Path(candidate.rel_path).stem
+        return html, title
+    if ext == ".docx":
+        return _convert_docx(path, candidate, result)
+    if ext == ".py":
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        snippets = detect_likely_html_strings_in_py(text)
+        if not snippets:
+            raise ValueError("No embeddable HTML found")
+        html = snippets[0][1]
+        title, body = extract_html_title_and_body(html)
+        return body, title
+    raise ValueError(f"Unsupported page type: {ext}")
+
+
+def _convert_markdown(text: str, options: ImportOptions, result: ImportResult) -> str:
+    if markdown_lib is None:
+        result.warnings.append("markdown library not available; returning plain text")
+        return f"<pre>{_escape_html(text)}</pre>"
+    extensions: list[str] = ["extra"]
+    if options.md_flavor == "gfm":
+        extra_exts: list[str] = []
+        for module_name in ("pymdownx.github", "mdx_gfm"):
+            try:  # pragma: no cover - optional
+                importlib.import_module(module_name)
+            except Exception:
+                continue
+            extra_exts.append(module_name)
+            break
+        if not extra_exts:
+            result.warnings.append("GFM extensions not available; using basic markdown")
+        extensions.extend(extra_exts or ["toc"])
+    return markdown_lib.markdown(text, extensions=extensions)
+
+
+def _convert_text(text: str, options: ImportOptions) -> str:
+    if not options.text_wrap_paragraphs:
+        return f"<pre>{_escape_html(text)}</pre>"
+    paragraphs = [p.strip() for p in text.splitlines()]
+    blocks: list[str] = []
+    buf: list[str] = []
+    for line in paragraphs:
+        if not line:
+            if buf:
+                blocks.append(" ".join(buf))
+                buf = []
+            continue
+        buf.append(line)
+    if buf:
+        blocks.append(" ".join(buf))
+    return "\n".join(f"<p>{_escape_html(block)}</p>" for block in blocks)
+
+
+def _convert_ipynb(path: Path, candidate: PageCandidate, result: ImportResult) -> tuple[str, str]:
+    if nbformat is None or HTMLExporter is None:
+        raise ValueError("nbconvert not available")
+    notebook = nbformat.read(path, as_version=4)
+    exporter = HTMLExporter()
+    body, _ = exporter.from_notebook_node(notebook)
+    title, content = extract_html_title_and_body(body)
+    if not title:
+        title = Path(candidate.rel_path).stem
+    return content, title
+
+
+def _convert_rst(text: str, result: ImportResult) -> str:
+    if publish_parts is None:
+        result.warnings.append("docutils not available; treating as plain text")
+        return f"<pre>{_escape_html(text)}</pre>"
+    parts = publish_parts(text, writer_name="html")
+    return parts.get("body", "")
+
+
+def _convert_docx(path: Path, candidate: PageCandidate, result: ImportResult) -> tuple[str, str]:
+    if mammoth is None:
+        raise ValueError("mammoth not available")
+    with path.open("rb") as fh:
+        converted = mammoth.convert_to_html(fh)
+    html = converted.value
+    title, body = extract_html_title_and_body(html)
+    if not title:
+        title = Path(candidate.rel_path).stem
+    return body, title
+
+
+def extract_html_title_and_body(html: str) -> tuple[str, str]:
+    if BeautifulSoup is None:
+        title = _simple_match(r"<title>(.*?)</title>", html)
+        body = _simple_match(r"<body[^>]*>(.*)</body>", html, flags=re.DOTALL) or html
+        return (title or "", body.strip())
+
+    soup = BeautifulSoup(html, "html.parser")
+    title = ""
+    if soup.title and soup.title.string:
+        title = soup.title.string.strip()
+    if not title:
+        h1 = soup.find("h1")
+        if h1 and h1.get_text(strip=True):
+            title = h1.get_text(strip=True)
+    if not title:
+        title = ""
+
+    body_container = soup.find("main") or soup.body or soup
+    if body_container is None:
+        return title, html
+    if body_container.name in {"html", "body"}:
+        contents = body_container.decode_contents()
+    else:
+        contents = body_container.decode()
+    return title, contents.strip()
+
+
+def rewrite_html_links(html: str, mapping: Dict[str, str]) -> str:
+    if BeautifulSoup is None:
+        return _rewrite_html_fallback(html, mapping)
+
+    soup = BeautifulSoup(html, "html.parser")
+
+    attrs_map = {
+        "a": ["href"],
+        "img": ["src", "srcset"],
+        "link": ["href"],
+        "script": ["src"],
+        "video": ["src", "poster"],
+        "source": ["src", "srcset"],
+        "audio": ["src"],
+    }
+
+    for tag_name, attrs in attrs_map.items():
+        for tag in soup.find_all(tag_name):
+            for attr in attrs:
+                value = tag.get(attr)
+                if not value:
+                    continue
+                if attr == "srcset":
+                    new_value = _rewrite_srcset(value, mapping)
+                else:
+                    new_value = _rewrite_url_value(value, mapping)
+                if new_value != value:
+                    tag[attr] = new_value
+
+    return str(soup)
+
+
+def _rewrite_html_fallback(html: str, mapping: Dict[str, str]) -> str:
+    from html.parser import HTMLParser
+    import html as html_lib
+
+    class _Parser(HTMLParser):
+        def __init__(self) -> None:
+            super().__init__(convert_charrefs=False)
+            self.out: list[str] = []
+
+        def handle_starttag(self, tag: str, attrs: list[tuple[str, Optional[str]]]) -> None:
+            self.out.append("<" + tag)
+            self._write_attrs(tag, attrs)
+            self.out.append(">")
+
+        def handle_startendtag(self, tag: str, attrs: list[tuple[str, Optional[str]]]) -> None:
+            self.out.append("<" + tag)
+            self._write_attrs(tag, attrs)
+            self.out.append("/>")
+
+        def handle_endtag(self, tag: str) -> None:
+            self.out.append(f"</{tag}>")
+
+        def handle_data(self, data: str) -> None:
+            self.out.append(data)
+
+        def handle_comment(self, data: str) -> None:
+            self.out.append(f"<!--{data}-->")
+
+        def handle_decl(self, decl: str) -> None:
+            self.out.append(f"<!{decl}>")
+
+        def handle_entityref(self, name: str) -> None:
+            self.out.append(f"&{name};")
+
+        def handle_charref(self, name: str) -> None:
+            self.out.append(f"&#{name};")
+
+        def _write_attrs(self, tag: str, attrs: list[tuple[str, Optional[str]]]) -> None:
+            for key, value in attrs:
+                val = value
+                if value:
+                    if key == "srcset":
+                        val = _rewrite_srcset(value, mapping)
+                    else:
+                        val = _rewrite_url_value(value, mapping)
+                if val is None:
+                    self.out.append(f" {key}")
+                else:
+                    escaped = html_lib.escape(val, quote=True)
+                    self.out.append(f" {key}=\"{escaped}\"")
+
+    parser = _Parser()
+    parser.feed(html)
+    parser.close()
+    return "".join(parser.out)
+
+
+def rewrite_css_urls(css: str, rewriter: Callable[[str], str]) -> str:
+    pattern = re.compile(r"url\(\s*(['\"]?)([^'\"]+?)\1\s*\)")
+
+    def repl(match: re.Match[str]) -> str:
+        quote = match.group(1)
+        value = match.group(2)
+        new_value = rewriter(value)
+        return f"url({quote}{new_value}{quote})"
+
+    return pattern.sub(repl, css)
+
+
+def detect_likely_html_strings_in_py(source: str) -> list[tuple[int, str]]:
+    triple_re = re.compile(r"([\"\']{3})(.+?)\1", re.DOTALL)
+    results: list[tuple[int, str]] = []
+    for match in triple_re.finditer(source):
+        snippet = match.group(2)
+        score = len(re.findall(r"<([a-zA-Z][a-zA-Z0-9]*)", snippet))
+        if score > 0:
+            results.append((score, snippet.strip()))
+    results.sort(key=lambda item: item[0], reverse=True)
+    return results
+
+
+def slugify_filename(name: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9-]+", "-", name).strip("-").lower()
+    return slug or "page"
+
+
+def _rewrite_url_value(value: str, mapping: Dict[str, str]) -> str:
+    value = value.strip()
+    if value.startswith("data:"):
+        return value
+    if value.startswith("#"):
+        return value
+    parsed = urlparse(value)
+    if parsed.scheme or parsed.netloc:
+        return value
+    normalized = _normalize_rel(parsed.path)
+    if normalized in mapping:
+        new_path = mapping[normalized]
+    else:
+        alt = normalized.lstrip("./")
+        new_path = mapping.get(alt)
+    if not new_path:
+        return value
+    rebuilt = urlunparse(parsed._replace(path=new_path))
+    return rebuilt
+
+
+def _normalize_rel(value: str) -> str:
+    cleaned = value.replace("\\", "/")
+    return str(PurePosixPath(cleaned))
+
+
+def _hash_file(path: Path) -> str:
+    digest = hashlib.sha1()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(8192), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _read_file_base64(path: Path) -> str | None:
+    try:
+        data = path.read_bytes()
+    except Exception:
+        return None
+    return base64.b64encode(data).decode("ascii")
+
+
+def _unique_asset_name(name: str, taken: set[str]) -> str:
+    base = Path(name).stem
+    suffix = Path(name).suffix
+    sanitized = slugify_filename(base)
+    candidate = f"{sanitized}{suffix}" if sanitized else name
+    if candidate not in taken:
+        return candidate
+    counter = 2
+    while True:
+        next_name = f"{sanitized}-{counter}{suffix}"
+        if next_name not in taken:
+            return next_name
+        counter += 1
+
+
+def _is_hidden(relative: Path) -> bool:
+    return any(part.startswith(".") for part in relative.parts)
+
+
+def _simple_match(pattern: str, text: str, flags: int = 0) -> str | None:
+    match = re.search(pattern, text, flags | re.IGNORECASE)
+    if match:
+        return match.group(1).strip()
+    return None
+
+
+def _escape_html(text: str) -> str:
+    import html
+
+    return html.escape(text, quote=False)
+
+
+def _first_heading(text: str) -> str:
+    heading = re.search(r"^#\s+(.+)$", text, flags=re.MULTILINE)
+    if heading:
+        return heading.group(1).strip()
+    return ""
+
+
+def _first_non_empty_line(text: str) -> str:
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped[:80]
+    return ""
+
+
+def _rewrite_srcset(value: str, mapping: Dict[str, str]) -> str:
+    parts = [part.strip() for part in value.split(",") if part.strip()]
+    rewritten_parts: list[str] = []
+    for part in parts:
+        if " " in part:
+            url_part, descriptor = part.split(" ", 1)
+            new_url = _rewrite_url_value(url_part, mapping)
+            rewritten_parts.append(f"{new_url} {descriptor.strip()}")
+        else:
+            rewritten_parts.append(_rewrite_url_value(part, mapping))
+    return ", ".join(rewritten_parts)
+

--- a/sitebuilder/ui/main_window.py
+++ b/sitebuilder/ui/main_window.py
@@ -1,26 +1,30 @@
-﻿from __future__ import annotations
+"""Main application window for the site builder."""
+
+from __future__ import annotations
 
 import os
-import tempfile
 import shutil
+import tempfile
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Dict, Optional
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 from PyQt6.QtWebEngineWidgets import QWebEngineView
 
-from ..core.models import Project, Page
-from ..core import storage, generator
+from ..core import generator, storage
+from ..core.models import Page, Project
+from ..importers import ALLOWED_EXTS_DEFAULT, ImportOptions, ImportResult, import_into_project
 
 APP_TITLE = "PyQt Site Builder"
+
 
 class MainWindow(QtWidgets.QMainWindow):
     def __init__(self) -> None:
         super().__init__()
         self.setWindowTitle(APP_TITLE)
-        self.resize(1220, 780)
+        self.resize(1240, 800)
 
-        # State
         self.project: Optional[Project] = None
         self.project_path: Optional[Path] = None
         self._preview_tmp: Optional[str] = None
@@ -29,93 +33,103 @@ class MainWindow(QtWidgets.QMainWindow):
         self._debounce.setSingleShot(True)
         self._debounce.timeout.connect(self.update_preview)
 
-        # UI
+        self._current_page_index: int = 0
+
         self._build_ui()
         self._build_menu()
         self._bind_events()
 
-        # Start with an empty project
         self.new_project_bootstrap()
 
-    # ---------- UI ----------
+    # ------------------------------------------------------------------ UI --
     def _build_ui(self) -> None:
         splitter = QtWidgets.QSplitter(self)
         splitter.setOrientation(QtCore.Qt.Orientation.Horizontal)
         self.setCentralWidget(splitter)
 
-        # Left: pages list + buttons
-        left = QtWidgets.QWidget(self)
-        left_layout = QtWidgets.QVBoxLayout(left)
-        left_layout.setContentsMargins(6,6,6,6)
+        # Pages panel
+        left_panel = QtWidgets.QWidget(self)
+        left_layout = QtWidgets.QVBoxLayout(left_panel)
+        left_layout.setContentsMargins(6, 6, 6, 6)
         left_layout.setSpacing(6)
 
-        self.pages_list = QtWidgets.QListWidget(left)
+        self.pages_list = QtWidgets.QListWidget(left_panel)
         self.pages_list.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.SingleSelection)
 
-        btn_bar = QtWidgets.QHBoxLayout()
-        self.btn_add_page = QtWidgets.QPushButton("Add Page")
-        self.btn_remove_page = QtWidgets.QPushButton("Remove Page")
-        btn_bar.addWidget(self.btn_add_page)
-        btn_bar.addWidget(self.btn_remove_page)
+        btn_row = QtWidgets.QHBoxLayout()
+        self.btn_add_page = QtWidgets.QPushButton("Add Page", left_panel)
+        self.btn_remove_page = QtWidgets.QPushButton("Remove Page", left_panel)
+        btn_row.addWidget(self.btn_add_page)
+        btn_row.addWidget(self.btn_remove_page)
 
-        left_layout.addWidget(QtWidgets.QLabel("Pages"))
+        left_layout.addWidget(QtWidgets.QLabel("Pages", left_panel))
         left_layout.addWidget(self.pages_list, 1)
-        left_layout.addLayout(btn_bar)
+        left_layout.addLayout(btn_row)
 
-        # Middle: editors (HTML + CSS)
-        mid = QtWidgets.QTabWidget(self)
-        mid.setDocumentMode(True)
-        self.html_editor = QtWidgets.QPlainTextEdit(mid)
+        # Editors + assets tabs
+        mid_tabs = QtWidgets.QTabWidget(self)
+        mid_tabs.setDocumentMode(True)
+
+        self.html_editor = QtWidgets.QPlainTextEdit(mid_tabs)
         self.html_editor.setPlaceholderText("<h2>Hello</h2>\n<p>Edit your page HTML here.</p>")
-        self.css_editor = QtWidgets.QPlainTextEdit(mid)
+        self.css_editor = QtWidgets.QPlainTextEdit(mid_tabs)
         self.css_editor.setPlaceholderText("/* Global site CSS lives here */")
-        mid.addTab(self.html_editor, "Page HTML")
-        mid.addTab(self.css_editor, "Styles (CSS)")
+        self.assets_view = QtWidgets.QListWidget(mid_tabs)
+        self.assets_view.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.SingleSelection)
+        self.assets_view.setUniformItemSizes(True)
 
-        # Right: preview
-        right = QtWidgets.QWidget(self)
-        right_layout = QtWidgets.QVBoxLayout(right)
-        right_layout.setContentsMargins(6,6,6,6)
+        mid_tabs.addTab(self.html_editor, "Page HTML")
+        mid_tabs.addTab(self.css_editor, "Styles (CSS)")
+        mid_tabs.addTab(self.assets_view, "Assets")
+
+        # Preview
+        right_panel = QtWidgets.QWidget(self)
+        right_layout = QtWidgets.QVBoxLayout(right_panel)
+        right_layout.setContentsMargins(6, 6, 6, 6)
         right_layout.setSpacing(6)
 
-        self.preview = QWebEngineView(right)
-        right_layout.addWidget(QtWidgets.QLabel("Preview"))
+        self.preview = QWebEngineView(right_panel)
+        right_layout.addWidget(QtWidgets.QLabel("Preview", right_panel))
         right_layout.addWidget(self.preview, 1)
 
-        splitter.addWidget(left)
-        splitter.addWidget(mid)
-        splitter.addWidget(right)
-        splitter.setSizes([220, 520, 480])
+        splitter.addWidget(left_panel)
+        splitter.addWidget(mid_tabs)
+        splitter.addWidget(right_panel)
+        splitter.setSizes([240, 560, 520])
 
         self.status = self.statusBar()
 
     def _build_menu(self) -> None:
         bar = self.menuBar()
 
-        # File
-        m_file = bar.addMenu("&File")
+        file_menu = bar.addMenu("&File")
         act_new = QtGui.QAction("New Project", self)
-        act_open = QtGui.QAction("Open Projectâ€¦", self)
+        act_open = QtGui.QAction("Open Project…", self)
+        act_import = QtGui.QAction("Import Site/Project…", self)
         act_save = QtGui.QAction("Save", self)
-        act_save_as = QtGui.QAction("Save Asâ€¦", self)
-        act_export = QtGui.QAction("Export Siteâ€¦", self)
+        act_save_as = QtGui.QAction("Save As…", self)
+        act_export = QtGui.QAction("Export Site…", self)
         act_quit = QtGui.QAction("Quit", self)
-        m_file.addActions([act_new, act_open])
-        m_file.addSeparator()
-        m_file.addActions([act_save, act_save_as])
-        m_file.addSeparator()
-        m_file.addAction(act_export)
-        m_file.addSeparator()
-        m_file.addAction(act_quit)
 
-        self.act_new, self.act_open, self.act_save, self.act_save_as, self.act_export, self.act_quit = \
-            act_new, act_open, act_save, act_save_as, act_export, act_quit
+        file_menu.addActions([act_new, act_open, act_import])
+        file_menu.addSeparator()
+        file_menu.addActions([act_save, act_save_as])
+        file_menu.addSeparator()
+        file_menu.addAction(act_export)
+        file_menu.addSeparator()
+        file_menu.addAction(act_quit)
 
-        # Help
-        m_help = bar.addMenu("&Help")
-        act_about = QtGui.QAction("About", self)
-        m_help.addAction(act_about)
-        self.act_about = act_about
+        self.act_new = act_new
+        self.act_open = act_open
+        self.act_import = act_import
+        self.act_save = act_save
+        self.act_save_as = act_save_as
+        self.act_export = act_export
+        self.act_quit = act_quit
+
+        help_menu = bar.addMenu("&Help")
+        self.act_about = QtGui.QAction("About", self)
+        help_menu.addAction(self.act_about)
 
     def _bind_events(self) -> None:
         self.btn_add_page.clicked.connect(self.add_page)
@@ -127,29 +141,31 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.act_new.triggered.connect(self.new_project_bootstrap)
         self.act_open.triggered.connect(self.open_project_dialog)
+        self.act_import.triggered.connect(self.import_project_dialog)
         self.act_save.triggered.connect(self.save_project)
         self.act_save_as.triggered.connect(self.save_project_as)
         self.act_export.triggered.connect(self.export_site)
         self.act_quit.triggered.connect(self.close)
         self.act_about.triggered.connect(self.show_about)
 
-    # ---------- Project Ops ----------
+    # ----------------------------------------------------------- Project Ops --
     def new_project_bootstrap(self) -> None:
         name, ok = QtWidgets.QInputDialog.getText(self, "New Project", "Site name:", text="My Site")
         if not ok or not name.strip():
             return
         self.project = Project(
             name=name.strip(),
-            pages=[
-                Page(filename="index.html", title="Home", html=self._default_index_html())
-            ],
+            pages=[Page(filename="index.html", title="Home", html=self._default_index_html())],
             css=self._default_css(),
             output_dir=None,
         )
+        self.project.assets.clear()
         self.project_path = None
+        self._current_page_index = 0
         self._refresh_pages_list(select_index=0)
+        self._refresh_assets_list()
         self.css_editor.setPlainText(self.project.css)
-        self.html_editor.setPlainText(self.project.pages[0].html)
+        self._load_page_into_editor(0)
         self.update_window_title()
         self.update_preview()
 
@@ -160,20 +176,23 @@ class MainWindow(QtWidgets.QMainWindow):
         self.project = storage.load_project(path)
         self.project_path = Path(path)
         self._refresh_pages_list(select_index=0)
+        self._refresh_assets_list()
+        if self.project.pages:
+            self._load_page_into_editor(0)
         self.css_editor.setPlainText(self.project.css)
-        self.html_editor.setPlainText(self.project.pages[0].html)
         self.update_window_title()
         self.update_preview()
-        self.status.showMessage(f"Opened {os.path.basename(path)}", 3000)
+        self.status.showMessage(f"Opened {os.path.basename(path)}", 4000)
 
     def save_project(self) -> None:
         if self.project is None:
             return
         self._flush_editors_to_model()
         if not self.project_path:
-            return self.save_project_as()
+            self.save_project_as()
+            return
         storage.save_project(self.project_path, self.project)
-        self.status.showMessage("Project saved", 2000)
+        self.status.showMessage("Project saved", 2500)
 
     def save_project_as(self) -> None:
         if self.project is None:
@@ -182,18 +201,17 @@ class MainWindow(QtWidgets.QMainWindow):
         path, _ = QtWidgets.QFileDialog.getSaveFileName(self, "Save Project As", "", "Site Project (*.siteproj)")
         if not path:
             return
-        if not path.endswith(".siteproj"):
-            path += ".siteproj"
+        path = path if path.endswith(".siteproj") else f"{path}.siteproj"
         storage.save_project(path, self.project)
         self.project_path = Path(path)
         self.update_window_title()
-        self.status.showMessage(f"Saved {os.path.basename(path)}", 3000)
+        self.status.showMessage(f"Saved {os.path.basename(path)}", 4000)
 
     def export_site(self) -> None:
         if self.project is None:
             return
         self._flush_editors_to_model()
-        out_dir = QtWidgets.QFileDialog.getExistingDirectory(self, "Export Site Toâ€¦")
+        out_dir = QtWidgets.QFileDialog.getExistingDirectory(self, "Export Site To…")
         if not out_dir:
             return
         templates_dir = Path(__file__).resolve().parent.parent / "core" / "templates"
@@ -201,24 +219,106 @@ class MainWindow(QtWidgets.QMainWindow):
         self.status.showMessage(f"Exported site to {out_dir}", 5000)
         QtWidgets.QMessageBox.information(self, "Export complete", f"Your site was exported to:\n{out_dir}")
 
-    # ---------- Pages ----------
+    def import_project_dialog(self) -> None:
+        if self.project is None:
+            return
+        self._flush_editors_to_model()
+
+        dialog = ImportDialog(self)
+        if dialog.exec() != QtWidgets.QDialog.DialogCode.Accepted:
+            return
+
+        selection = dialog.selection()
+        if not selection:
+            return
+        source_type, paths = selection
+        options = dialog.options()
+
+        cleanup_dir: Optional[Path] = None
+        source_path: Path
+        if source_type == "files":
+            cleanup_dir = Path(tempfile.mkdtemp(prefix="sitebuilder_import_"))
+            for src in paths:
+                src_path = Path(src)
+                dest = cleanup_dir / src_path.name
+                try:
+                    shutil.copy2(src_path, dest)
+                except Exception as exc:
+                    QtWidgets.QMessageBox.warning(self, "Import", f"Failed to include {src_path}: {exc}")
+            source_path = cleanup_dir
+        else:
+            source_path = Path(paths[0])
+
+        target_project = self.project
+        new_project_created = False
+        if options.create_new_project:
+            target_project = Project(name="Imported Site", pages=[], css=self._default_css(), output_dir=None)
+            new_project_created = True
+
+        existing_positions = {page.filename: idx for idx, page in enumerate(target_project.pages)}
+
+        progress = QtWidgets.QProgressDialog("Importing content…", None, 0, 1, self)
+        progress.setWindowTitle("Importing")
+        progress.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
+        progress.setMinimumDuration(0)
+        progress.setCancelButton(None)
+
+        def on_progress(current: int, total: int) -> None:
+            progress.setMaximum(total)
+            progress.setValue(current)
+            QtCore.QCoreApplication.processEvents(QtCore.QEventLoop.ProcessEventsFlag.AllEvents, 50)
+
+        try:
+            result = import_into_project(target_project, source_path, options, progress_callback=on_progress)
+        finally:
+            progress.close()
+            if cleanup_dir:
+                shutil.rmtree(cleanup_dir, ignore_errors=True)
+
+        if new_project_created:
+            self.project = target_project
+            self.project_path = None
+
+        if result.errors:
+            self.status.showMessage("Import completed with errors", 5000)
+        else:
+            self.status.showMessage("Import complete", 5000)
+
+        new_index = 0
+        for idx, page in enumerate(target_project.pages):
+            if page.filename not in existing_positions:
+                new_index = idx
+                break
+        else:
+            if existing_positions:
+                new_index = min(existing_positions.values())
+            elif target_project.pages:
+                new_index = 0
+
+        self._refresh_pages_list(select_index=new_index)
+        self._refresh_assets_list()
+        self.css_editor.setPlainText(target_project.css)
+        self.update_preview()
+        self.update_window_title()
+
+        _show_import_summary(self, result)
+
+    # --------------------------------------------------------------- Pages --
     def add_page(self) -> None:
         if self.project is None:
             return
         title, ok = QtWidgets.QInputDialog.getText(self, "Add Page", "Page title:", text="About")
         if not ok or not title.strip():
             return
-        slug = "-".join(title.lower().split())
-        filename = f"{slug}.html" if slug != "index" else "index.html"
-        # Avoid duplicates
+        slug = "-".join(title.lower().split()) or "page"
+        filename = f"{slug}.html"
         existing = {p.filename for p in self.project.pages}
-        n = 1
-        base_filename = filename
+        counter = 2
         while filename in existing:
-            filename = f"{slug}-{n}.html"
-            n += 1
-        self.project.pages.append(Page(filename=filename, title=title.strip(), html=f"<h2>{title.strip()}</h2>\n<p>Write something awesome.</p>"))
-        self._refresh_pages_list(select_index=len(self.project.pages)-1)
+            filename = f"{slug}-{counter}.html"
+            counter += 1
+        self.project.pages.append(Page(filename=filename, title=title.strip(), html=f"<h2>{title}</h2>\n<p>New page.</p>"))
+        self._refresh_pages_list(select_index=len(self.project.pages) - 1)
         self.update_preview()
 
     def remove_page(self) -> None:
@@ -232,94 +332,94 @@ class MainWindow(QtWidgets.QMainWindow):
             QtWidgets.QMessageBox.warning(self, "Not allowed", "You cannot remove the home page (index.html).")
             return
         del self.project.pages[row]
-        self._refresh_pages_list(select_index=max(0, row-1))
+        self._refresh_pages_list(select_index=max(0, row - 1))
         self.update_preview()
 
     def _refresh_pages_list(self, select_index: int = 0) -> None:
-     """Refresh the left-hand Pages list and select a row."""
-     self.pages_list.blockSignals(True)
-     self.pages_list.clear()
-     if self.project:
-        for p in self.project.pages:
-            self.pages_list.addItem(f"{p.title}  ({p.filename})")
-     self.pages_list.blockSignals(False)
+        self.pages_list.blockSignals(True)
+        self.pages_list.clear()
+        if self.project:
+            for page in self.project.pages:
+                self.pages_list.addItem(f"{page.title}  ({page.filename})")
+        self.pages_list.blockSignals(False)
 
-     count = self.pages_list.count()
-     if count == 0:
-        return
-    # Clamp the selection index to [0, count-1]
-     if select_index < 0:
-        select_index = 0
-     elif select_index >= count:
-        select_index = count - 1
-     self.pages_list.setCurrentRow(select_index)
+        count = self.pages_list.count()
+        if count == 0:
+            return
+        select_index = max(0, min(select_index, count - 1))
+        self._current_page_index = select_index
+        self.pages_list.blockSignals(True)
+        self.pages_list.setCurrentRow(select_index)
+        self.pages_list.blockSignals(False)
+        self._load_page_into_editor(select_index)
+
+    def _refresh_assets_list(self) -> None:
+        self.assets_view.clear()
+        if not self.project:
+            return
+        for asset in self.project.assets:
+            item = QtWidgets.QListWidgetItem(f"{asset.kind}: {asset.name}")
+            self.assets_view.addItem(item)
 
     def _on_page_selection_changed(self, row: int) -> None:
         if self.project is None or row < 0 or row >= len(self.project.pages):
             return
-        # Save current edits back to previously selected page
-        self._flush_editors_to_model()
-        # Load selected page into editor
-        page = self.project.pages[row]
-        self.html_editor.blockSignals(True)
-        self.html_editor.setPlainText(page.html)
-        self.html_editor.blockSignals(False)
+        self._flush_editors_to_model(self._current_page_index)
+        self._current_page_index = row
+        self._load_page_into_editor(row)
         self.update_preview()
 
-    # ---------- Editing & Preview ----------
+    # ---------------------------------------------------- Editing & Preview --
     def _on_editor_changed(self) -> None:
         self._debounce.start()
 
-    def _flush_editors_to_model(self) -> None:
+    def _flush_editors_to_model(self, row: Optional[int] = None) -> None:
         if self.project is None:
             return
-        row = self.pages_list.currentRow()
-        if row < 0 or row >= len(self.project.pages):
-            return
+        if row is None:
+            row = self._current_page_index
+        if 0 <= row < len(self.project.pages):
+            self.project.pages[row].html = self.html_editor.toPlainText()
         self.project.css = self.css_editor.toPlainText()
-        self.project.pages[row].html = self.html_editor.toPlainText()
 
     def update_preview(self) -> None:
         if self.project is None:
             return
-        # Make sure model reflects editors
         self._flush_editors_to_model()
 
-        # Build to a temp directory
         if self._preview_tmp and os.path.isdir(self._preview_tmp):
             shutil.rmtree(self._preview_tmp, ignore_errors=True)
         self._preview_tmp = tempfile.mkdtemp(prefix="sitebuilder_preview_")
         templates_dir = Path(__file__).resolve().parent.parent / "core" / "templates"
         generator.render_site(self.project, self._preview_tmp, templates_dir)
 
-        # Load current page into preview
         row = self.pages_list.currentRow()
-        if row < 0:
+        if row < 0 and self.project.pages:
             row = 0
-        curr = self.project.pages[row]
-        path = Path(self._preview_tmp) / curr.filename
-        self.preview.setUrl(QtCore.QUrl.fromLocalFile(str(path)))
+        if 0 <= row < len(self.project.pages):
+            page = self.project.pages[row]
+            path = Path(self._preview_tmp) / page.filename
+            self.preview.setUrl(QtCore.QUrl.fromLocalFile(str(path)))
 
-    # ---------- Misc ----------
+    # ---------------------------------------------------------------- Misc --
     def show_about(self) -> None:
         QtWidgets.QMessageBox.information(
             self,
             "About",
-            f"{APP_TITLE}\n\nA minimal website generator and editor built with PyQt6."
+            f"{APP_TITLE}\n\nA minimal website generator and editor built with PyQt6.",
         )
 
     def update_window_title(self) -> None:
         name = self.project.name if self.project else "Untitled"
-        suffix = f" â€” {self.project_path.name}" if self.project_path else ""
-        self.setWindowTitle(f"{APP_TITLE} â€” {name}{suffix}")
+        suffix = f" — {self.project_path.name}" if self.project_path else ""
+        self.setWindowTitle(f"{APP_TITLE} — {name}{suffix}")
 
-    def closeEvent(self, event: QtGui.QCloseEvent) -> None:
-        # Clean preview tmp
+    def closeEvent(self, event: QtGui.QCloseEvent) -> None:  # noqa: N802 (Qt override)
         if self._preview_tmp and os.path.isdir(self._preview_tmp):
             shutil.rmtree(self._preview_tmp, ignore_errors=True)
-        event.accept()
+        super().closeEvent(event)
 
-    # ---------- Defaults ----------
+    # --------------------------------------------------------------- Defaults --
     def _default_css(self) -> str:
         return (
             "/* Global site styles */\n"
@@ -345,5 +445,288 @@ class MainWindow(QtWidgets.QMainWindow):
             "</section>\n"
         )
 
-def find_templates_dir() -> Path:
-    return Path(__file__).resolve().parent.parent / "core" / "templates"
+    def _load_page_into_editor(self, index: int) -> None:
+        if self.project is None or not (0 <= index < len(self.project.pages)):
+            self.html_editor.clear()
+            return
+        page = self.project.pages[index]
+        self.html_editor.blockSignals(True)
+        self.html_editor.setPlainText(page.html)
+        self.html_editor.blockSignals(False)
+
+
+def _show_import_summary(parent: QtWidgets.QWidget, result: ImportResult) -> None:
+    summary_lines = [
+        f"Files scanned: {result.files_scanned}",
+        f"Pages imported: {result.pages_imported}",
+        f"CSS files merged: {result.css_files_merged}",
+        f"Assets copied: {result.assets_copied}",
+    ]
+
+    message = QtWidgets.QMessageBox(parent)
+    message.setWindowTitle("Import summary")
+    message.setIcon(QtWidgets.QMessageBox.Icon.Warning if result.errors else QtWidgets.QMessageBox.Icon.Information)
+    message.setText("\n".join(summary_lines))
+
+    inline: list[str] = []
+    if result.errors:
+        inline.extend(result.errors[:3])
+    if result.warnings:
+        inline.extend(result.warnings[:7])
+        if len(result.warnings) > 7:
+            inline.append("…")
+    if inline:
+        message.setInformativeText("\n".join(inline))
+
+    details: list[str] = []
+    if result.errors:
+        details.append("Errors:\n" + "\n".join(result.errors))
+    if result.warnings:
+        details.append("Warnings:\n" + "\n".join(result.warnings))
+    if details:
+        message.setDetailedText("\n\n".join(details))
+
+    message.exec()
+
+
+# ---------------------------------------------------------------------------
+# Import dialog
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ExtensionItem:
+    label: str
+    enabled: bool
+    tooltip: str = ""
+
+
+class ImportDialog(QtWidgets.QDialog):
+    def __init__(self, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Import Content")
+        self.resize(620, 520)
+
+        self._selected_files: list[str] = []
+        self._selected_path: str = ""
+
+        layout = QtWidgets.QVBoxLayout(self)
+
+        layout.addWidget(QtWidgets.QLabel("Source"))
+
+        src_box = QtWidgets.QGroupBox("Source type", self)
+        src_layout = QtWidgets.QHBoxLayout(src_box)
+        self.radio_folder = QtWidgets.QRadioButton("Folder", src_box)
+        self.radio_zip = QtWidgets.QRadioButton("Zip", src_box)
+        self.radio_files = QtWidgets.QRadioButton("Files", src_box)
+        self.radio_folder.setChecked(True)
+        src_layout.addWidget(self.radio_folder)
+        src_layout.addWidget(self.radio_zip)
+        src_layout.addWidget(self.radio_files)
+
+        layout.addWidget(src_box)
+
+        path_layout = QtWidgets.QHBoxLayout()
+        self.path_edit = QtWidgets.QLineEdit(self)
+        self.path_edit.setReadOnly(True)
+        self.browse_btn = QtWidgets.QPushButton("Browse…", self)
+        path_layout.addWidget(self.path_edit, 1)
+        path_layout.addWidget(self.browse_btn)
+        layout.addLayout(path_layout)
+
+        behavior_box = QtWidgets.QGroupBox("Behavior", self)
+        behavior_layout = QtWidgets.QGridLayout(behavior_box)
+
+        self.merge_current_radio = QtWidgets.QRadioButton("Merge into current project", behavior_box)
+        self.create_new_radio = QtWidgets.QRadioButton("Create new project from import", behavior_box)
+        self.merge_current_radio.setChecked(True)
+
+        behavior_layout.addWidget(self.merge_current_radio, 0, 0, 1, 2)
+        behavior_layout.addWidget(self.create_new_radio, 1, 0, 1, 2)
+
+        behavior_layout.addWidget(QtWidgets.QLabel("Conflict handling:"), 2, 0)
+        self.conflict_combo = QtWidgets.QComboBox(behavior_box)
+        self.conflict_combo.addItems(["Keep both", "Overwrite", "Skip"])
+        behavior_layout.addWidget(self.conflict_combo, 2, 1)
+
+        behavior_layout.addWidget(QtWidgets.QLabel("CSS merge:"), 3, 0)
+        self.css_combo = QtWidgets.QComboBox(behavior_box)
+        self.css_combo.addItems(["Append", "Prepend", "Replace"])
+        behavior_layout.addWidget(self.css_combo, 3, 1)
+
+        self.rewrite_links_check = QtWidgets.QCheckBox("Rewrite page links", behavior_box)
+        self.rewrite_links_check.setChecked(True)
+        self.rewrite_assets_check = QtWidgets.QCheckBox("Rewrite asset URLs", behavior_box)
+        self.rewrite_assets_check.setChecked(True)
+        behavior_layout.addWidget(self.rewrite_links_check, 4, 0, 1, 2)
+        behavior_layout.addWidget(self.rewrite_assets_check, 5, 0, 1, 2)
+
+        layout.addWidget(behavior_box)
+
+        self.advanced_button = QtWidgets.QToolButton(self)
+        self.advanced_button.setText("Show advanced ▸")
+        self.advanced_button.setCheckable(True)
+        self.advanced_button.setToolButtonStyle(QtCore.Qt.ToolButtonStyle.ToolButtonTextOnly)
+        layout.addWidget(self.advanced_button)
+
+        self.advanced_widget = QtWidgets.QWidget(self)
+        advanced_layout = QtWidgets.QFormLayout(self.advanced_widget)
+        self.page_filename_combo = QtWidgets.QComboBox(self.advanced_widget)
+        self.page_filename_combo.addItems(["Slugify", "Keep original", "Prefix on collision"])
+        self.markdown_combo = QtWidgets.QComboBox(self.advanced_widget)
+        self.markdown_combo.addItems(["GitHub Flavored", "CommonMark"])
+        self.wrap_text_check = QtWidgets.QCheckBox("Wrap plain text paragraphs", self.advanced_widget)
+        self.wrap_text_check.setChecked(True)
+        self.home_index_check = QtWidgets.QCheckBox("Set home page to index.html when present", self.advanced_widget)
+        self.home_index_check.setChecked(True)
+        self.ignore_hidden_check = QtWidgets.QCheckBox("Ignore hidden files", self.advanced_widget)
+        self.ignore_hidden_check.setChecked(True)
+        self.include_js_check = QtWidgets.QCheckBox("Include JavaScript files", self.advanced_widget)
+        self.include_js_check.setChecked(True)
+
+        advanced_layout.addRow("Filename strategy", self.page_filename_combo)
+        advanced_layout.addRow("Markdown flavor", self.markdown_combo)
+        advanced_layout.addRow(self.wrap_text_check)
+        advanced_layout.addRow(self.home_index_check)
+        advanced_layout.addRow(self.ignore_hidden_check)
+        advanced_layout.addRow(self.include_js_check)
+
+        self.ext_list = QtWidgets.QListWidget(self.advanced_widget)
+        self.ext_list.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.MultiSelection)
+        advanced_layout.addRow("Allowed extensions", self.ext_list)
+
+        layout.addWidget(self.advanced_widget)
+        self.advanced_widget.setVisible(False)
+
+        self.advanced_button.toggled.connect(self._toggle_advanced)
+        self.browse_btn.clicked.connect(self._on_browse)
+
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
+            parent=self,
+        )
+        buttons.button(QtWidgets.QDialogButtonBox.StandardButton.Ok).setText("Import")
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+        self._populate_extensions()
+
+    def _toggle_advanced(self, checked: bool) -> None:
+        self.advanced_button.setText("Hide advanced ◂" if checked else "Show advanced ▸")
+        self.advanced_widget.setVisible(checked)
+
+    def _populate_extensions(self) -> None:
+        ext_items = self._build_extension_items()
+        for entry in ext_items:
+            item = QtWidgets.QListWidgetItem(entry.label, self.ext_list)
+            item.setFlags(item.flags() | QtCore.Qt.ItemFlag.ItemIsUserCheckable)
+            if not entry.enabled:
+                item.setFlags(item.flags() & ~QtCore.Qt.ItemFlag.ItemIsEnabled)
+            item.setCheckState(QtCore.Qt.CheckState.Checked if entry.enabled else QtCore.Qt.CheckState.Unchecked)
+            if entry.tooltip:
+                item.setToolTip(entry.tooltip)
+
+    def _build_extension_items(self) -> list[_ExtensionItem]:
+        items: list[_ExtensionItem] = []
+        optional_tips: Dict[str, str] = {
+            ".docx": "Requires the 'mammoth' package",
+            ".rst": "Requires the 'docutils' package",
+            ".ipynb": "Requires nbconvert and nbformat",
+        }
+        from .. import importers
+
+        for ext in sorted(ALLOWED_EXTS_DEFAULT):
+            enabled = True
+            tip = ""
+            if ext == ".docx" and getattr(importers, "mammoth", None) is None:
+                enabled = False
+                tip = optional_tips[ext]
+            elif ext == ".rst" and getattr(importers, "publish_parts", None) is None:
+                enabled = False
+                tip = optional_tips[ext]
+            elif ext == ".ipynb" and (getattr(importers, "nbformat", None) is None or getattr(importers, "HTMLExporter", None) is None):
+                enabled = False
+                tip = optional_tips[ext]
+            items.append(_ExtensionItem(label=ext, enabled=enabled, tooltip=tip))
+        return items
+
+    def _on_browse(self) -> None:
+        if self.radio_folder.isChecked():
+            path = QtWidgets.QFileDialog.getExistingDirectory(self, "Select folder")
+            if path:
+                self._selected_path = path
+                self._selected_files = []
+                self.path_edit.setText(path)
+        elif self.radio_zip.isChecked():
+            path, _ = QtWidgets.QFileDialog.getOpenFileName(self, "Select zip", "", "Zip Archives (*.zip)")
+            if path:
+                self._selected_path = path
+                self._selected_files = []
+                self.path_edit.setText(path)
+        else:
+            files, _ = QtWidgets.QFileDialog.getOpenFileNames(
+                self,
+                "Select files",
+                "",
+                "Content files (*.html *.htm *.md *.markdown *.txt *.ipynb *.rst *.css *.js);;All files (*)",
+            )
+            if files:
+                self._selected_files = files
+                self._selected_path = ""
+                self.path_edit.setText(f"{len(files)} file(s) selected")
+
+    def selection(self) -> tuple[str, list[str]] | None:
+        if self.radio_files.isChecked():
+            if not self._selected_files:
+                QtWidgets.QMessageBox.warning(self, "Import", "Select at least one file to import.")
+                return None
+            return "files", self._selected_files
+        path = self._selected_path
+        if not path:
+            QtWidgets.QMessageBox.warning(self, "Import", "Select a source to import.")
+            return None
+        if self.radio_folder.isChecked():
+            return "folder", [path]
+        return "zip", [path]
+
+    def options(self) -> ImportOptions:
+        allowed_exts = set()
+        for i in range(self.ext_list.count()):
+            item = self.ext_list.item(i)
+            if item.checkState() == QtCore.Qt.CheckState.Checked:
+                allowed_exts.add(item.text())
+        conflict_map = {
+            "Keep both": "keep-both",
+            "Overwrite": "overwrite",
+            "Skip": "skip",
+        }
+        css_map = {
+            "Append": "append",
+            "Prepend": "prepend",
+            "Replace": "replace",
+        }
+        filename_map = {
+            "Slugify": "slugify",
+            "Keep original": "keep",
+            "Prefix on collision": "prefix-collisions",
+        }
+        md_map = {
+            "GitHub Flavored": "gfm",
+            "CommonMark": "commonmark",
+        }
+        return ImportOptions(
+            create_new_project=self.create_new_radio.isChecked(),
+            page_filename_strategy=filename_map[self.page_filename_combo.currentText()],
+            conflict_policy=conflict_map[self.conflict_combo.currentText()],
+            merge_css=css_map[self.css_combo.currentText()],
+            rewrite_links=self.rewrite_links_check.isChecked(),
+            rewrite_asset_urls=self.rewrite_assets_check.isChecked(),
+            md_flavor=md_map[self.markdown_combo.currentText()],
+            text_wrap_paragraphs=self.wrap_text_check.isChecked(),
+            set_home_to_index_if_present=self.home_index_check.isChecked(),
+            ignore_hidden=self.ignore_hidden_check.isChecked(),
+            include_js_files=self.include_js_check.isChecked(),
+            allowed_extensions=allowed_exts or set(ALLOWED_EXTS_DEFAULT),
+        )
+

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from sitebuilder.importers import (
+    extract_html_title_and_body,
+    rewrite_css_urls,
+    rewrite_html_links,
+    slugify_filename,
+    detect_likely_html_strings_in_py,
+)
+
+
+def test_extract_html_title_and_body_prefers_main_section() -> None:
+    html = """<html><head><title>Sample</title></head><body><main><h1>Heading</h1><p>Body</p></main></body></html>"""
+    title, body = extract_html_title_and_body(html)
+    assert title == "Sample"
+    assert "<h1>Heading</h1>" in body
+
+
+def test_slugify_filename_generates_safe_names() -> None:
+    assert slugify_filename("My Test Page!") == "my-test-page"
+    assert slugify_filename("   ") == "page"
+
+
+def test_rewrite_html_links_updates_targets() -> None:
+    html = "<a href='about.html'>About</a><img src=\"images/logo.png\"/>"
+    mapping = {
+        "about.html": "about-us.html",
+        "images/logo.png": "assets/images/logo.png",
+    }
+    rewritten = rewrite_html_links(html, mapping)
+    assert "about-us.html" in rewritten
+    assert "assets/images/logo.png" in rewritten
+
+
+def test_rewrite_css_urls_invokes_rewriter() -> None:
+    css = "body{background:url('img/bg.png');}"
+
+    def rewriter(value: str) -> str:
+        return "assets/images/bg.png" if value == "img/bg.png" else value
+
+    rewritten = rewrite_css_urls(css, rewriter)
+    assert "assets/images/bg.png" in rewritten
+
+
+def test_detect_likely_html_strings_in_py_finds_triple_quotes() -> None:
+    source = 'PAGE = """<div><p>Hello</p></div>"""\nother = """plain"""'
+    matches = detect_likely_html_strings_in_py(source)
+    assert matches
+    score, snippet = matches[0]
+    assert score > 0
+    assert "<p>Hello</p>" in snippet
+


### PR DESCRIPTION
## Summary
- add a modular import pipeline covering pages, CSS, and assets with link rewriting helpers
- extend the project model and exporter to retain assets alongside HTML/CSS
- wire a File → Import dialog with progress, options, and helper unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce0bd553948322908141658b91b474

## Summary by Sourcery

Implement a flexible site import pipeline and integrate an Import dialog into the UI, extend project models and generator to handle assets, and add unit tests for import helpers

New Features:
- Add modular import pipeline for external site content including pages, CSS, and assets with link rewriting support
- Add 'Import Site/Project' dialog in the main UI with progress reporting and advanced and simple import options
- Introduce Asset model support in Project model, UI assets tab, and bundling of assets in the export generator

Enhancements:
- Refactor main window layout and page/asset selection logic with updated panel sizes
- Extend core generator to write bundled assets into appropriate 'assets' subdirectories during site export

Tests:
- Add unit tests for import pipeline utilities: HTML title/body extraction, CSS URL rewriting, HTML link rewriting, filename slugification, and Python HTML snippet detection